### PR TITLE
Improve redirect functionality

### DIFF
--- a/1.0-latest/MathJax.js
+++ b/1.0-latest/MathJax.js
@@ -1,25 +1,51 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/1.1a/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/1.0-latest/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/1.1-latest/MathJax.js
+++ b/1.1-latest/MathJax.js
@@ -1,25 +1,51 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/1.1a/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/1.1-latest/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/1.1-latest/unpacked/MathJax.js
+++ b/1.1-latest/unpacked/MathJax.js
@@ -1,25 +1,51 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/1.1a/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/1.1-latest/unpacked/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/2.0-latest/MathJax.js
+++ b/2.0-latest/MathJax.js
@@ -1,25 +1,51 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.0.0/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/2.0-latest/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/2.0-latest/unpacked/MathJax.js
+++ b/2.0-latest/unpacked/MathJax.js
@@ -1,26 +1,52 @@
 
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.0.0/MathJax.js';
-  var n = oldMathJax.length;
   var oldMathJax = 'cdn.mathjax.org/mathjax/2.0-latest/unpacked/MathJax.js';
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/2.1-latest/MathJax.js
+++ b/2.1-latest/MathJax.js
@@ -1,25 +1,51 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.1.0/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/2.1-latest/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/2.1-latest/unpacked/MathJax.js
+++ b/2.1-latest/unpacked/MathJax.js
@@ -1,25 +1,51 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.1.0/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/2.1-latest/unpacked/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/2.2-latest/MathJax.js
+++ b/2.2-latest/MathJax.js
@@ -1,27 +1,54 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.2.0/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/2.2-latest/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }
+  }
   }
 })();

--- a/2.2-latest/unpacked/MathJax.js
+++ b/2.2-latest/unpacked/MathJax.js
@@ -1,25 +1,51 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.2.0/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/2.2-latest/unpacked/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/2.3-latest/MathJax.js
+++ b/2.3-latest/MathJax.js
@@ -1,25 +1,51 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.3.0/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/2.3-latest/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/2.3-latest/unpacked/MathJax.js
+++ b/2.3-latest/unpacked/MathJax.js
@@ -1,25 +1,51 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.3.0/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/2.3-latest/unpacked/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/2.4-latest/MathJax.js
+++ b/2.4-latest/MathJax.js
@@ -1,25 +1,51 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.4.0/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/2.4-latest/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/2.4-latest/unpacked/MathJax.js
+++ b/2.4-latest/unpacked/MathJax.js
@@ -1,25 +1,51 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.4.0/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/2.4-latest/unpacked/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/2.5-latest/MathJax.js
+++ b/2.5-latest/MathJax.js
@@ -1,25 +1,51 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.5.3/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/2.5-latest/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/2.5-latest/unpacked/MathJax.js
+++ b/2.5-latest/unpacked/MathJax.js
@@ -1,27 +1,53 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.5.3/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/2.5-latest/unpacked/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }
   }
-})();
+)();

--- a/2.6-latest/MathJax.js
+++ b/2.6-latest/MathJax.js
@@ -1,25 +1,51 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.6.1/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/2.6-latest/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/2.6-latest/unpacked/MathJax.js
+++ b/2.6-latest/unpacked/MathJax.js
@@ -1,25 +1,51 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.6.1/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/2.6-latest/unpacked/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/2.7-latest/MathJax.js
+++ b/2.7-latest/MathJax.js
@@ -1,25 +1,51 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/2.7-latest/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/2.7-latest/unpacked/MathJax.js
+++ b/2.7-latest/unpacked/MathJax.js
@@ -1,25 +1,51 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/2.7-latest/unpacked/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/latest/MathJax.js
+++ b/latest/MathJax.js
@@ -1,25 +1,51 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/latest/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/latest/unpacked/MathJax.js
+++ b/latest/unpacked/MathJax.js
@@ -1,25 +1,51 @@
 (function () {
   var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js';
   var oldMathJax = 'cdn.mathjax.org/mathjax/latest/unpacked/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/test/MathJax.js
+++ b/test/MathJax.js
@@ -1,25 +1,46 @@
 (function () {
-  var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js';
+  var newMathJax = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js';
   var oldMathJax = 'rawgit.com/mathjax/cdn-redirect/master/test/MathJax.js';
-  var n = oldMathJax.length;
 
-  var replaceScript = function (script, rawSrc) {
+  var replaceScript = function (script, src) {
     var newScript = document.createElement('script');
-    newScript.src = newMathJax + rawSrc.substr(n);
+    newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
+    //
+    //  Move onload and onerror handlers to new script
+    //
+    newScript.onload = script.onload; 
+    newScript.onerror = script.onerror;
+    script.onload = script.onerror = null;
+    //
+    //  Move any content (old-style configuration scripts)
+    //
+    while (script.firstChild) newScript.appendChild(script.firstChild);
+    //
+    //  Move script id
+    //
+    //  Replace original script with new one
+    //
     script.parentNode.replaceChild(newScript, script);
+    //
+    //  Issue a console warning
+    //
     console.warn('WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.')
   }
+
   if (document.currentScript) {
     var script = document.currentScript;
-    replaceScript(script, script.src.replace(/^(https?:)?\/\//i, ''));
+    replaceScript(script, script.src);
   } else {
+    //
+    // Look for current script by searching for one with the right source
+    //
+    var n = oldMathJax.length;
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
       var script = scripts[i];
-      var src = script.src || '//';
-      var rawSrc = src.split('//')[1];
-      if (rawSrc.substr(0, n) === oldMathJax) {
-        replaceScript(script, rawSrc);
+      var src = (script.src || '').replace(/.*?:\/\//,'');
+      if (src.substr(0, n) === oldMathJax) {
+        replaceScript(script, src);
         break;
       }
     }

--- a/test/MathJax.js
+++ b/test/MathJax.js
@@ -3,6 +3,9 @@
   var oldMathJax = 'rawgit.com/mathjax/cdn-redirect/master/test/MathJax.js';
 
   var replaceScript = function (script, src) {
+    //
+    //  Make redirected script
+    //
     var newScript = document.createElement('script');
     newScript.src = newMathJax + src.replace(/.*?(\?|$)/, '$1');
     //
@@ -16,7 +19,9 @@
     //
     while (script.firstChild) newScript.appendChild(script.firstChild);
     //
-    //  Move script id
+    //  Copy script id
+    //
+    if (script.id != null) newScript.id = script.id;
     //
     //  Replace original script with new one
     //


### PR DESCRIPTION
The changes include:

* Moving `onload` and `onerror` handlers from the old script to the new one
* Moving any content of the old script (e.g., old-style configuration script) to the new one
* Copying he script `id`, if any.
* Adding comments
* Alternative means of getting the configuration parameters

So this should accommodate more legacy situations.